### PR TITLE
Persist database with Docker volume

### DIFF
--- a/quizout-server/app/__init__.py
+++ b/quizout-server/app/__init__.py
@@ -32,7 +32,7 @@ def create_app():
     with open(api_secret_path, "r") as f:
         app.config['SECRET_KEY'] = f.read()
 
-    db_path = os.getenv("SQLITE_PATH", "/data/db.sqlite")
+    db_path = os.path.expanduser(os.getenv("SQLITE_PATH", "/data/db.sqlite"))
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
 
     db.init_app(app)

--- a/quizout-server/app/__init__.py
+++ b/quizout-server/app/__init__.py
@@ -32,7 +32,8 @@ def create_app():
     with open(api_secret_path, "r") as f:
         app.config['SECRET_KEY'] = f.read()
 
-    app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///db.sqlite'
+    db_path = os.getenv("SQLITE_PATH", "/data/db.sqlite")
+    app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_path}'
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/quizout-server/compose.yaml
+++ b/quizout-server/compose.yaml
@@ -11,7 +11,7 @@ services:
       - api_secret
       - db_pass
     volumes:
-      - quizout-data:/app/db.sqlite
+      - quizout-data:/data
   web:
     image: nginx
     volumes:

--- a/quizout-server/compose.yaml
+++ b/quizout-server/compose.yaml
@@ -10,6 +10,8 @@ services:
       - api_key
       - api_secret
       - db_pass
+    volumes:
+      - quizout-data:/app/db.sqlite
   web:
     image: nginx
     volumes:
@@ -27,3 +29,5 @@ secrets:
     file: ~/.quizoutserver/secrets/api_secret
   db_pass:
     file: ~/.quizoutserver/secrets/db_pass
+volumes:
+  quizout-data:

--- a/quizout-server/compose.yaml
+++ b/quizout-server/compose.yaml
@@ -3,6 +3,7 @@ services:
     environment:
       - SECRET_LOCATION=/run/secrets/
       - DEBUG=True
+      - SQLITE_PATH=/data/db.sqlite
     build: .
     expose:
       - 8000


### PR DESCRIPTION
## Summary
- add a named volume for the SQLite database
- declare the `quizout-data` volume for docker-compose

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_687ec6ad542c832a8d7861618f9b6b7f