### PR TITLE
Sanitize REST API inputs

### DIFF
--- a/quizout-server/app/utils/__init__.py
+++ b/quizout-server/app/utils/__init__.py
@@ -1,1 +1,1 @@
-# from . import flask_addons
+from .sanitize import sanitize_id, sanitize_str, sanitize_datetime

--- a/quizout-server/app/utils/__init__.py
+++ b/quizout-server/app/utils/__init__.py
@@ -1,1 +1,2 @@
 from .sanitize import sanitize_id, sanitize_str, sanitize_datetime
+from .json_error_handler import json_error_handler

--- a/quizout-server/app/utils/json_error_handler.py
+++ b/quizout-server/app/utils/json_error_handler.py
@@ -1,0 +1,15 @@
+import json
+
+def json_error_handler(e):
+    """Return JSON instead of HTML for HTTP errors."""
+    # start with the correct headers and status code from the error
+    response = e.get_response()
+
+    # replace the body with JSON
+    response.data = json.dumps({
+        "code": e.code,
+        "name": e.name,
+        "description": e.description,
+    })
+    response.content_type = "application/json"
+    return response

--- a/quizout-server/app/utils/sanitize.py
+++ b/quizout-server/app/utils/sanitize.py
@@ -1,5 +1,4 @@
 from markupsafe import escape
-from werkzeug.exceptions import BadRequest
 import datetime
 import re
 
@@ -8,10 +7,12 @@ MAX_STR_LEN = 1024
 
 def sanitize_id(id_value: str) -> int:
     """Convert id parameter to int, raising BadRequest if invalid."""
-    try:
-        return int(id_value)
-    except (TypeError, ValueError):
-        raise BadRequest("Invalid id parameter")
+    intValue = int(id_value)
+
+    if (intValue < 0):
+        raise ValueError("ID numbers must be positive integers")
+    
+    return intValue
 
 
 def sanitize_str(value: str, max_length: int = MAX_STR_LEN) -> str:
@@ -22,9 +23,9 @@ def sanitize_str(value: str, max_length: int = MAX_STR_LEN) -> str:
     enforces a length limit to avoid overflow attacks.
     """
     if not isinstance(value, str):
-        raise BadRequest("Invalid input type")
+        raise ValueError("Invalid input type")
     if len(value) > max_length:
-        raise BadRequest("Input too long")
+        raise ValueError("Input too long")
 
     # Escape HTML first to neutralize script tags
     escaped_value = escape(value)
@@ -38,8 +39,6 @@ def sanitize_str(value: str, max_length: int = MAX_STR_LEN) -> str:
 def sanitize_datetime(value: str) -> datetime.datetime:
     """Parse ISO formatted datetime string."""
     if not isinstance(value, str):
-        raise BadRequest("Invalid datetime format")
-    try:
-        return datetime.datetime.fromisoformat(value)
-    except ValueError:
-        raise BadRequest("Invalid datetime format")
+        raise ValueError("Invalid datetime format")
+    
+    return datetime.datetime.fromisoformat(value)

--- a/quizout-server/app/utils/sanitize.py
+++ b/quizout-server/app/utils/sanitize.py
@@ -1,6 +1,10 @@
 from markupsafe import escape
 from werkzeug.exceptions import BadRequest
 import datetime
+import re
+
+# Default maximum length for sanitized strings
+MAX_STR_LEN = 1024
 
 def sanitize_id(id_value: str) -> int:
     """Convert id parameter to int, raising BadRequest if invalid."""
@@ -10,11 +14,25 @@ def sanitize_id(id_value: str) -> int:
         raise BadRequest("Invalid id parameter")
 
 
-def sanitize_str(value: str) -> str:
-    """Escape string inputs to avoid injection."""
+def sanitize_str(value: str, max_length: int = MAX_STR_LEN) -> str:
+    """Validate and sanitize a string value.
+
+    This helper escapes HTML to mitigate HTML/JS injection attempts,
+    removes a few characters commonly used in SQL injections and
+    enforces a length limit to avoid overflow attacks.
+    """
     if not isinstance(value, str):
         raise BadRequest("Invalid input type")
-    return escape(value)
+    if len(value) > max_length:
+        raise BadRequest("Input too long")
+
+    # Escape HTML first to neutralize script tags
+    escaped_value = escape(value)
+
+    # Remove characters frequently used for SQL/JS injection
+    cleaned_value = re.sub(r"[\"';`]|--", "", escaped_value)
+
+    return cleaned_value
 
 
 def sanitize_datetime(value: str) -> datetime.datetime:

--- a/quizout-server/app/utils/sanitize.py
+++ b/quizout-server/app/utils/sanitize.py
@@ -1,0 +1,27 @@
+from markupsafe import escape
+from werkzeug.exceptions import BadRequest
+import datetime
+
+def sanitize_id(id_value: str) -> int:
+    """Convert id parameter to int, raising BadRequest if invalid."""
+    try:
+        return int(id_value)
+    except (TypeError, ValueError):
+        raise BadRequest("Invalid id parameter")
+
+
+def sanitize_str(value: str) -> str:
+    """Escape string inputs to avoid injection."""
+    if not isinstance(value, str):
+        raise BadRequest("Invalid input type")
+    return escape(value)
+
+
+def sanitize_datetime(value: str) -> datetime.datetime:
+    """Parse ISO formatted datetime string."""
+    if not isinstance(value, str):
+        raise BadRequest("Invalid datetime format")
+    try:
+        return datetime.datetime.fromisoformat(value)
+    except ValueError:
+        raise BadRequest("Invalid datetime format")


### PR DESCRIPTION
## Summary
- sanitize string and datetime inputs
- validate id parameters
- expose sanitize helpers in utils

## Testing
- `find quizout-server/app -name '*.py' | xargs python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_688b30f769c4832ab3234b3c8f073789